### PR TITLE
Change Travis build to use Molecule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,40 @@
 ---
 language: python
-python: "2.7"
+python: '2.7'
 
-# Use the new container infrastructure
-sudo: false
+# Require the standard build environment
+sudo: required
 
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
+# Require Ubuntu 14.04
+dist: trusty
+
+# Require Docker
+services:
+  - docker
+
+# Cache Ansible and Molecule to speed things up
+cache:
+  - pip
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -o Dpkg::Options::='--force-confold' --force-yes -y docker-engine
 
 install:
-  # Install ansible
+  # Install Ansible
   - pip install ansible
 
-  # Check ansible version
+  # Install Molecule
+  - pip install 'molecule==1.10.3'
+
+  # Check Ansible version
   - ansible --version
 
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
+  # Check Molecule version
+  - molecule --version
 
 script:
-  # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/


### PR DESCRIPTION
The Travis CI build currently only runs a syntax check; it should run the full Molecule build.
