### PR TITLE
Dropped documented support for Ubuntu Wily

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Requirements
 * Ubuntu
 
     * Trusty (14.04)
-    * Wily (15.10)
     * Xenial (16.04)
     * Note: other Ubuntu versions may work but have not been tested.
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,6 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - trusty
-        - wily
         - xenial
   galaxy_tags:
     - terminator


### PR DESCRIPTION
It's no longer a supported Ubuntu version.