### PR TITLE
Removed unnecessary ca-certificates install

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,4 @@
 ---
-- name: ensure ca-certificates installed
-  become: yes
-  apt:
-    name: ca-certificates
-    state: present
-
 - name: add terminator ppa
   become: yes
   apt_repository:


### PR DESCRIPTION
It can reasonably be expected to be present. It was only added due to an earlier version of Molecule.