### PR TITLE
Removed Terminator PPA

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: add terminator ppa
-  become: yes
-  apt_repository:
-    repo: 'ppa:gnome-terminator'
-
 - name: install terminator
   become: yes
   apt:


### PR DESCRIPTION
It's a core package and the PPA doesn't provide releases for Ubuntu Bionic.