### PR TITLE
Added role_name to the Ansible Galaxy metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 galaxy_info:
+  role_name: terminator
   author: John Freeman
   description: Role for installing the Terminator terminal emulator.
   company: GantSign Ltd.


### PR DESCRIPTION
Needed since Ansible Galaxy 3 to have a role name different to the repo name.